### PR TITLE
Fix census service

### DIFF
--- a/app/services/census_service.rb
+++ b/app/services/census_service.rb
@@ -34,7 +34,7 @@ class CensusService
     res = conn.get do |req|
       req.url '/api/v1/users/by_github'
       req.params['q'] = username
-      req.params['access_token'] = ENV['CENSUS_TOKEN']
+      req.params['access_token'] = get_token
     end
     JSON.parse(res.body)
   end

--- a/config/application.sample.yml
+++ b/config/application.sample.yml
@@ -1,3 +1,2 @@
 CENSUS_CLIENT_ID: client_id
 CENSUS_SECRET_ID: secret
-CENSUS_TOKEN: token


### PR DESCRIPTION
@notmarkmiranda Can you take a look at this?

# Changes

* Changes the CensusService to get a new token for each request for student info rather than use tokens set in the environment.
* Removes `CENSUS_TOKEN` from the `application.sample.yml`

# Reasons for Changes

* JohariWindowAPI was not pulling in cohorts from students. Appears that the token stored in the Heroku ENV was stale and therefore Census was telling us that we were unauthorized.
* `get_token` was already built out, so just needed to change the request to use that token instead of a stored token.
* With that change, appears that we no longer need `CENSUS_TOKEN` in the ENV.

# Downsides

* In order to get tests to pass with this change I had to delete cassettes.
* Appears that the cassettes have been checked in.
* Cassettes use `filter_sensitive_data` in `spec/rails_helper.rb` to make sure that the Census tokens are not committed.
* The changed code doesn't register as `CENSUS_TOKEN`, so the token gets added to the cassettes.

# Potential Solution

* Delete the cassettes.
* Commit.
* Add cassettes to `.gitignore`
* I never know if this works. It feels like every time I do this someone else manages to add the cassettes back in. Help?

Let me know what you think.